### PR TITLE
Dynamic Version Table

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,12 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.13"
       - name: Install PDM
         uses: pdm-project/setup-pdm@v4
       - name: Install dependencies and build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,4 +37,4 @@ jobs:
           pdm run test
       - name: Run formatting checks
         run: |
-          pdm run black --check .
+          pdm run black --check --extend-exclude vendor/ .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,14 +3,14 @@ name: Tests
 on:
   push:
     paths:
-      - '**.py'
-      - 'pdm.lock'
-      - 'pyproject.toml'
+      - "**.py"
+      - "pdm.lock"
+      - "pyproject.toml"
   pull_request:
     paths:
-      - '**.py'
-      - 'pdm.lock'
-      - 'pyproject.toml'
+      - "**.py"
+      - "pdm.lock"
+      - "pyproject.toml"
   workflow_dispatch:
 
 jobs:
@@ -18,21 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install PDM
-      uses: pdm-project/setup-pdm@v4
-    - name: Install dependencies
-      run: |
-        pdm install -dG :all
-    - name: Run tests
-      run: |
-        pdm run pytest
-    - name: Run formatting checks
-      run: |
-        pdm run black --check .
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install PDM
+        uses: pdm-project/setup-pdm@v4
+      - name: Install dependencies
+        run: |
+          pdm install -dG :all
+      - name: Run tests
+        run: |
+          pdm run test
+      - name: Run formatting checks
+        run: |
+          pdm run black --check .

--- a/.github/workflows/vendor.yaml
+++ b/.github/workflows/vendor.yaml
@@ -1,0 +1,25 @@
+name: Update duckdb submodule
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch: ~
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+      - uses: sgoudham/update-git-submodules@v2.1.1
+        id: submodule
+        with:
+          strategy: tag
+      - uses: peter-evans/create-pull-request@v7
+        if: ${{ steps.submodule.outputs['duckdb--updated'] }}
+        with:
+          title: "New DuckDB version ${{ steps.submodule.outputs['duckdb--latestTag'] }}"
+          commit-message: "Update DuckDB submodule ref to ${{ steps.submodule.outputs['duckdb--latestTag'] }}"
+          body: ${{ steps.submodule.outputs.prBody }}
+          branch: duckdb-vendor-submodule

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/duckdb_upgrade/duckdb"]
+	path = vendor/duckdb
+	url = git@github.com:duckdb/duckdb.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "src/duckdb_upgrade/duckdb"]
+[submodule "duckdb"]
 	path = vendor/duckdb
 	url = git@github.com:duckdb/duckdb.git

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,11 +2,13 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "black", "lint", "test"]
-cross_platform = true
-static_urls = false
-lock_version = "4.3"
-content_hash = "sha256:43218bcc248678d4a39bbb5f86f84bfaca98ea857f3e9e4e85a666d07f15193d"
+groups = ["default", "lint", "test"]
+strategy = []
+lock_version = "4.5.0"
+content_hash = "sha256:5bf91f36434ecf360c3da38bebe3a61208cb3c9e313d13967cf8f7b34cb9c7a6"
+
+[[metadata.targets]]
+requires_python = ">=3.8"
 
 [[package]]
 name = "black"
@@ -149,6 +151,7 @@ requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
 dependencies = [
     "colorama; platform_system == \"Windows\"",
+    "importlib-metadata; python_version < \"3.8\"",
 ]
 files = [
     {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
@@ -230,6 +233,9 @@ name = "platformdirs"
 version = "3.10.0"
 requires_python = ">=3.7"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+dependencies = [
+    "typing-extensions>=4.7.1; python_version < \"3.8\"",
+]
 files = [
     {file = "platformdirs-3.10.0-py3-none-any.whl", hash = "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"},
     {file = "platformdirs-3.10.0.tar.gz", hash = "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d"},
@@ -253,6 +259,7 @@ summary = "pytest: simple powerful testing with Python"
 dependencies = [
     "colorama; sys_platform == \"win32\"",
     "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
+    "importlib-metadata>=0.12; python_version < \"3.8\"",
     "iniconfig",
     "packaging",
     "pluggy<2.0,>=0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ requires-python = ">=3.8"
 readme = "README.md"
 license = {text = "MIT"}
 
+[build-system]
+requires = ["pdm-pep517"]
+build-backend = "pdm.pep517.api"
+
 [tool.pdm.dev-dependencies]
 lint = [
     "black>=23.7.0",
@@ -23,6 +27,20 @@ test = [
 
 [tool.pdm.scripts]
 duckdb-upgrade = {call = "src.duckdb_upgrade.__main__:main"}
+
+pre_build = {composite = [
+    "mkdir -p src/duckdb_upgrade/data",
+    """cp \
+        vendor/duckdb/src/storage/version_map.json \
+        src/duckdb_upgrade/data/version_map.json
+    """,
+]}
+
+[tool.pdm.build]
+includes = [
+    "src", 
+    "src/duckdb_upgrade/data/version_map.json"
+]
 
 [project.scripts]
 duckdb-upgrade = "duckdb_upgrade.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,16 @@ test = [
 
 [tool.pdm.scripts]
 duckdb-upgrade = {call = "src.duckdb_upgrade.__main__:main"}
-
 pre_build = {composite = [
     "mkdir -p src/duckdb_upgrade/data",
     """cp \
         vendor/duckdb/src/storage/version_map.json \
         src/duckdb_upgrade/data/version_map.json
     """,
+]}
+test = {composite = [
+    "pre_build",
+    "pytest --ignore=vendor/"
 ]}
 
 [tool.pdm.build]

--- a/src/duckdb_upgrade/.gitignore
+++ b/src/duckdb_upgrade/.gitignore
@@ -1,0 +1,2 @@
+# Ignore contents of data directory.
+data/

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -52,11 +52,11 @@ def test_version_lookup_latest() -> None:
 
     lookup = versions.VersionLookup()
     tests = [
-        Test(StorageVersion=0, Result=Version("1.1.0"), ShouldAssert=False),
+        Test(StorageVersion=0, Result=Version("1.2.0"), ShouldAssert=False),
         Test(StorageVersion=10000, Result=Version("0.0.0"), ShouldAssert=True),
     ] + [
         Test(StorageVersion=sv, Result=max(vs), ShouldAssert=False)
-        for sv, vs in lookup.VERSION_TABLE.items()
+        for sv, vs in lookup.version_table.items()
     ]
 
     for test in tests:
@@ -70,7 +70,7 @@ def test_version_lookup_latest() -> None:
 def test_version_lookup_all_versions_for_storage_number() -> None:
     lookup = versions.VersionLookup()
 
-    for sv, vs in lookup.VERSION_TABLE.items():
+    for sv, vs in lookup.version_table.items():
         assert lookup.all_versions_for_storage_number(sv) == vs
 
 
@@ -120,7 +120,7 @@ def test_version_lookup_get_download_url(monkeypatch: pytest.MonkeyPatch) -> Non
             Version=64,
             Platform="linux",
             Arch="x86_64",
-            Result="https://github.com/duckdb/duckdb/releases/download/v1.1.0/duckdb_cli-linux-amd64.zip",
+            Result="https://github.com/duckdb/duckdb/releases/download/v1.1.3/duckdb_cli-linux-amd64.zip",
             ShouldAssert=False,
         ),
         Test(


### PR DESCRIPTION
Introduces a change where the version table is generated from the JSON file the DuckDB project uses to perform c++ code generation to build their own version table. This should allow this tool to support newer versions of DuckDB without needing to manually add new versions to the table.

## Changes
* Added [duckdb](github.com/duckdb/duckdb) as a submodule in the `vendor/` directory.
* Changed `VersionLookup` class' init to load a JSON file containing a mapping of versions to storage numbers and turn it into a reversed lookup, similar to the old manual table.
* Updated build and test scripts to include vendored JSON data in resulting wheel and sdists.
* Added workflow to update duckdb repo commit in `.gitmodules` and open a PR when a new version is tagged.